### PR TITLE
Fixes the url for todoist api endpoint.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -9,8 +9,8 @@ import (
 
 const (
 	protocol          = "https://"
-	todoistHost       = "beta.todoist.com/"
-	todoistPathPrefix = "API/v8/"
+	todoistHost       = "api.todoist.com/"
+	todoistPathPrefix = "rest/v1/"
 )
 
 type Client struct {


### PR DESCRIPTION
This library stopped working for me because the endpoint for todoist changed. I fixed it in my fork and wanted to see if you want to merge it into your branch in case someone else is using it.  Thanks.